### PR TITLE
`TimeTable.GetWeeklyWorkTimes()` 정의/구현 및 `WeeklyTimeTableControl`에 적용

### DIFF
--- a/TimeManager/Controls/WeeklyTimeTableControl.cs
+++ b/TimeManager/Controls/WeeklyTimeTableControl.cs
@@ -52,14 +52,14 @@ namespace TimeManager.Controls
         public void DrawCells(TimeTable timeTable, Week week)
         {
             CleanCells();
-            DrawWorkTimes(timeTable);
+            DrawWorkTimes(timeTable, week);
             DrawSchedules(timeTable, week);
             DrawTasks(timeTable, week);
         }
 
-        private void DrawWorkTimes(TimeTable timeTable)
+        private void DrawWorkTimes(TimeTable timeTable, Week week)
         {
-            foreach (WeeklyDateTimeBlock block in timeTable.GetWeeklyWorkTimes(Week.From(DateTime.Now)))
+            foreach (WeeklyDateTimeBlock block in timeTable.GetWeeklyWorkTimes(week))
             {
                 int startRow = block.StartTime.Hour * 2 + block.StartTime.Minute / 30;
                 int endRow = block.EndTime.Hour * 2 + block.EndTime.Minute / 30;

--- a/TimeManager/Controls/WeeklyTimeTableControl.cs
+++ b/TimeManager/Controls/WeeklyTimeTableControl.cs
@@ -59,14 +59,14 @@ namespace TimeManager.Controls
 
         private void DrawWorkTimes(TimeTable timeTable)
         {
-            foreach (DateTimeBlock block in timeTable.WorkTimes)
+            foreach (WeeklyDateTimeBlock block in timeTable.GetWeeklyWorkTimes(Week.From(DateTime.Now)))
             {
-                int startRow = block.StartDate.Hour * 2 + block.StartDate.Minute / 30;
-                int endRow = block.EndDate.Hour * 2 + block.EndDate.Minute / 30;
+                int startRow = block.StartTime.Hour * 2 + block.StartTime.Minute / 30;
+                int endRow = block.EndTime.Hour * 2 + block.EndTime.Minute / 30;
 
                 for (int i = startRow; i < endRow; i++)
                 {
-                    dataGridView.Rows[i].Cells[block.StartDate.GetDayOfWeekIndex()].Style.BackColor = Color.White;
+                    dataGridView.Rows[i].Cells[block.DayOfWeek.GetDayOfWeekIndex()].Style.BackColor = Color.White;
                 }
             }
         }

--- a/TimeManager/Data/Model/ITimeTable.cs
+++ b/TimeManager/Data/Model/ITimeTable.cs
@@ -12,6 +12,7 @@ namespace TimeManager.Data.Model
         // TODO: 주 단위로 확장
         void SetWorkTimes(List<DateTimeBlock> workTimes);
         List<DateTimeBlock> GetWorkTimes();
+        List<WeeklyDateTimeBlock> GetWeeklyWorkTimes(Week week);
 
         /* AvailableTime Operations */
         List<DateTimeBlock> GetWeeklyAvailableTimes(Week week);

--- a/TimeManager/Data/Model/TimeTable.Operations.WorkAndAvailableTimes.cs
+++ b/TimeManager/Data/Model/TimeTable.Operations.WorkAndAvailableTimes.cs
@@ -21,6 +21,27 @@ namespace TimeManager.Data.Model
             return _workTimes;
         }
 
+        public List<WeeklyDateTimeBlock> GetWeeklyWorkTimes(Week week)
+        {
+            if (_workTimes == null || _workTimes.Count == 0)
+                return new List<WeeklyDateTimeBlock>();
+
+            List<WeeklyDateTimeBlock> weeklyWorkTimes = _workTimes
+                .FindAll(b => week.IsInWeek(b.StartDate))
+                .Select(b => new WeeklyDateTimeBlock
+                {
+                    DayOfWeek = b.StartDate.DayOfWeek,
+                    StartTime = b.StartDate,
+                    EndTime = b.EndDate
+                })
+                .ToList();
+
+            if (weeklyWorkTimes.Count == 0)
+                return GetWeeklyWorkTimes(week.PreviousWeek);
+
+            return weeklyWorkTimes;
+        }
+
 
         /* AvailableTime Operations */
         public List<DateTimeBlock> GetWeeklyAvailableTimes(Week week)

--- a/TimeManager/Data/Model/Week.cs
+++ b/TimeManager/Data/Model/Week.cs
@@ -14,6 +14,17 @@ namespace TimeManager.Data.Model
         public int WeekOfMonth { get; set; }
 
 
+        public Week PreviousWeek
+        {
+            get
+            {
+                DateTime startOfWeek = new DateTime(Year, Month, 1).FirstDayOfMonthHasDayOfWeek(DayOfWeek.Monday).AddDays((WeekOfMonth - 1) * 7);
+                DateTime previousWeek = startOfWeek.AddDays(-7);
+                return Week.From(previousWeek);
+            }
+        }
+
+
         public static Week From(DateTime dateTime)
         {
             DateTime startOfWeek = dateTime.StartOfWeek();

--- a/TimeManager/Extensions/DayOfWeekExtension.cs
+++ b/TimeManager/Extensions/DayOfWeekExtension.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TimeManager.Extensions
+{
+    public static class DayOfWeekExtension
+    {
+        public static int GetDayOfWeekIndexStartedFrom(this DayOfWeek dayOfWeek, DayOfWeek start = DayOfWeek.Monday)
+        {
+            return (7 + (dayOfWeek - start)) % 7;
+        }
+    }
+}

--- a/TimeManager/Extensions/DayOfWeekExtension.cs
+++ b/TimeManager/Extensions/DayOfWeekExtension.cs
@@ -8,7 +8,7 @@ namespace TimeManager.Extensions
 {
     public static class DayOfWeekExtension
     {
-        public static int GetDayOfWeekIndexStartedFrom(this DayOfWeek dayOfWeek, DayOfWeek start = DayOfWeek.Monday)
+        public static int GetDayOfWeekIndex(this DayOfWeek dayOfWeek, DayOfWeek start = DayOfWeek.Monday)
         {
             return (7 + (dayOfWeek - start)) % 7;
         }

--- a/TimeManager/TimeManager.csproj
+++ b/TimeManager/TimeManager.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Data\Repository\ITaskRepository.cs" />
     <Compile Include="Data\Repository\ITimeTableRepository.cs" />
     <Compile Include="Extensions\DateTimeExtension.cs" />
+    <Compile Include="Extensions\DayOfWeekExtension.cs" />
     <Compile Include="Forms\AddScheduleForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
<!--
[작성 방법]
(이 부분은 지우지 않아도 보이지 않습니다!)

작업 내역: 작업한 이슈 번호를 #번호의 형태로 태그합니다. 이슈는 Project에서 Convert To Issue를 통해 만들어진 이슈이며, `#번호`를 입력하면 자동으로 이슈와 연결되어, 작업 내역을 손쉽게 추적할 수 있습니다.
특이 사항: 원래 작업하기로 한 부분 외의 다른 파일 수정사항이 있거나, 요청사항이 있는 등, 작업 중 특이 사항이 있으면 메모합니다.

이 내용은 지울 필요 없고, 아래의 내용에 적절한 정보들을 기재한 후 PR을 올리시면 됩니다.
-->

## 작업 내역
- #47 

## 특이 사항
- `TimeTable.WorkTimes`가 `List<DateTimeBlock>` 형으로 되어 있어 서로 다른 주의 `WorkTimes`를 구분할 수 없는 문제가 있어, 해당 주에 대응하는 WorkTimes를 읽어오거나 없는 경우 가장 최근 주의 WorkTimes를 읽어오도록 수정하였습니다.
- 향후, `TimeTable.WorkTimes`가 `Dictionary<Week, WeeklyDateTimeBlock>` 형으로 변환하여 각 주마다 다른 WorkTime을 관리할 수 있도록 수정하는 것을 고려 중입니다. (#46)
