### PR TITLE
`GetAvailableTimesInBlock()` 내 올바르지 않은 날짜 정보 들어가는 문제 (진행 중)

### DIFF
--- a/TimeManager/Data/Model/TimeTable.Operations.WorkAndAvailableTimes.cs
+++ b/TimeManager/Data/Model/TimeTable.Operations.WorkAndAvailableTimes.cs
@@ -101,19 +101,20 @@ namespace TimeManager.Data.Model
             return _GetDailyAvailableTimes(date);
         }
 
-        private List<DateTimeBlock> _GetDailyAvailableTimes(DateTime date, int maxWeek = 48)
+        private List<DateTimeBlock> _GetDailyAvailableTimes(DateTime date, int currWeek = 0)
         {
-            if (maxWeek < 1)
+            if (currWeek < -48)
                 return new List<DateTimeBlock>();
 
             IEnumerable<DateTimeBlock> scheduleTimes = GetDailyAssignedSchedules(date)
                 .SelectMany(s => s.AssignedBlocks);
 
             IEnumerable<DateTimeBlock> dailyWorkTimes = _workTimes
-                .Where(b => b.StartDate.Date == date.Date);
+                .Where(b => b.StartDate.Date == date.Date)
+                .Select(b => new DateTimeBlock(b.StartDate.AddDays(-(currWeek * 7)), b.EndDate.AddDays(-(currWeek * 7))));
 
             if (dailyWorkTimes.Count() == 0)
-                return _GetDailyAvailableTimes(date.AddDays(-7), maxWeek - 1);
+                return _GetDailyAvailableTimes(date.AddDays(-7), currWeek - 1);
 
             return (List<DateTimeBlock>)DateTimeBlock.Difference(dailyWorkTimes, scheduleTimes);
         }

--- a/TimeManagerUnitTests/Data/Model/TimeTableWorkAndAvailableTimesUnitTests.cs
+++ b/TimeManagerUnitTests/Data/Model/TimeTableWorkAndAvailableTimesUnitTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TimeManager.Data.Model;
+
+namespace TimeManagerUnitTests.Model
+{
+    [TestClass]
+    public class TimeTableWorkAndAvailableTimesUnitTests
+    {
+        private TimeTable timeTable = new TimeTable();
+
+        [TestMethod]
+        public void GetAvailableTimesInBlock에서_하루에_대한_부분_가용시간을_가져올_수_있다()
+        {
+            timeTable.SetWorkTimes(new List<DateTimeBlock>() {
+                new DateTimeBlock(DateTime.Today.AddHours(9), DateTime.Today.AddHours(18)),
+
+            });
+
+            timeTable.AssignSchedule(1, new List<DateTimeBlock>() {
+                new DateTimeBlock(DateTime.Today.AddHours(12), DateTime.Today.AddHours(16))
+            });
+
+            List<DateTimeBlock> availableTimes = timeTable.GetAvailableTimesInBlock(new DateTimeBlock(
+                DateTime.Today.AddHours(8),
+                DateTime.Today.AddHours(17)
+            ));
+
+            Trace.WriteLine($"Available Blocks: {availableTimes.Count}");
+            Assert.IsTrue(availableTimes.Count == 2);
+
+            Assert.IsTrue(availableTimes[0].StartDate.Hour == 9 && availableTimes[0].EndDate.Hour == 12);
+            Assert.IsTrue(availableTimes[1].StartDate.Hour == 16 && availableTimes[1].EndDate.Hour == 18);
+
+            foreach (var availableTime in availableTimes)
+            {
+                Trace.WriteLine($"Available Time: {availableTime.StartDate} ~ {availableTime.EndDate}");
+                Assert.IsTrue(availableTime.StartDate.Hour >= 9 && availableTime.EndDate.Hour <= 12);
+            }
+        }
+    }
+}

--- a/TimeManagerUnitTests/TimeManagerUnitTests.csproj
+++ b/TimeManagerUnitTests/TimeManagerUnitTests.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Data\Model\TimeTableWorkAndAvailableTimesUnitTests.cs" />
     <Compile Include="Scheduler\ThunderSchedulerStrategyUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
<!--
[작성 방법]
(이 부분은 지우지 않아도 보이지 않습니다!)

작업 내역: 작업한 이슈 번호를 #번호의 형태로 태그합니다. 이슈는 Project에서 Convert To Issue를 통해 만들어진 이슈이며, `#번호`를 입력하면 자동으로 이슈와 연결되어, 작업 내역을 손쉽게 추적할 수 있습니다.
특이 사항: 원래 작업하기로 한 부분 외의 다른 파일 수정사항이 있거나, 요청사항이 있는 등, 작업 중 특이 사항이 있으면 메모합니다.

이 내용은 지울 필요 없고, 아래의 내용에 적절한 정보들을 기재한 후 PR을 올리시면 됩니다.
-->

## 작업 내역
- #120 

## 특이 사항
- `Difference()` 쪽에 문제가 있는 것으로 보입니다. 하루치에 대해 WorkTime 블럭에서 Schedule 블럭을 빼는 연산을 수행하면, 아무 블럭도 반환되지 않습니다. (@woongjee)
